### PR TITLE
Increase startupProbe for litellm

### DIFF
--- a/charts/litellm/values.yaml
+++ b/charts/litellm/values.yaml
@@ -74,9 +74,15 @@ litellm-helm:
       master_key: os.environ/PROXY_MASTER_KEY
       store_model_in_db: true
       store_prompts_in_spend_logs: false # This should only be true for specific debugging.
-  
+
+  livenessProbe:
+    timeoutSeconds: 3
+  readinessProbe:
+    timeoutSeconds: 3
   startupProbe:
     timeoutSeconds: 3
+    initialDelaySeconds: 5
+  
 prometheus:
   # RBAC configuration - required for cross-namespace pod discovery (e.g., envoy-gateway-system)
   rbac:

--- a/charts/litellm/values.yaml
+++ b/charts/litellm/values.yaml
@@ -76,8 +76,7 @@ litellm-helm:
       store_prompts_in_spend_logs: false # This should only be true for specific debugging.
   
   startupProbe:
-    timeoutSeconds: 30
-
+    timeoutSeconds: 3
 prometheus:
   # RBAC configuration - required for cross-namespace pod discovery (e.g., envoy-gateway-system)
   rbac:

--- a/charts/litellm/values.yaml
+++ b/charts/litellm/values.yaml
@@ -74,7 +74,9 @@ litellm-helm:
       master_key: os.environ/PROXY_MASTER_KEY
       store_model_in_db: true
       store_prompts_in_spend_logs: false # This should only be true for specific debugging.
-
+  
+  startupProbe:
+    timeoutSeconds: 30
 
 prometheus:
   # RBAC configuration - required for cross-namespace pod discovery (e.g., envoy-gateway-system)


### PR DESCRIPTION
## What does this PR do?

<!-- Briefly describe what this PR is about -->
Increases the default startupProbe from 1s to 30s for litellm

## Related issue(s)

<!-- 
Please link relevant issues to help with tracking.

Examples:
- Fixes #<issue number> or <issue link>
- Closes #<issue number> or <issue link>
- Relates #<issue number> or <issue link>
-->

PLAT-1000

## Related changes

<!-- Please link any other PRs or MRs related to this change. -->

## Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change which adds no functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How has this been tested?

<!-- Please describe the tests that you performed to verify your changes. -->

This will be applied first in the dev and staging clusters to verify changes.

## How and when this is going to be rolled out?

<!-- Please describe the rollout plan. -->

After the dev and staging clusters are updated with no breaking changes, it will be deployed using the mothership clusters to all clusters.

## Checklist

<!-- Make sure that you’ve checked the boxes below before you add any reviewers in the MR. -->

- [x] Assign yourself as the Assignee of this MR.
- [x] Review your changes before adding any reviewers.
- [ ] (If applicable) Documentation is updated (README, Notion etc.)
- [x] If you have multiple commits, please combine them into a few logically organized commits by squashing them.
- [ ] This PR contains substantial use of AI-assisted coding tools.

## Status

<!-- Please also mark the PR as Draft if it isn't ready for review. -->

- [ ] Ready for Review
