### PR TITLE
litellm: use patched litellm-lagoon-base-database image

### DIFF
--- a/charts/litellm/Chart.yaml
+++ b/charts/litellm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: litellm
 description: A Helm chart to refer the official litellm helm chart
 type: application
-version: 0.7.2
+version: 0.8.0
 dependencies:
   - name: litellm-helm
     version: 1.83.14-stable.patch.3

--- a/charts/litellm/values.yaml
+++ b/charts/litellm/values.yaml
@@ -18,7 +18,15 @@ externalSecrets:
 litellm-helm:
   enabled: true
   image:
-    tag: "main-stable"
+    # Upstream LiteLLM plus our pending upstream patches (currently
+    # BerriAI/litellm#31618), republished by
+    # https://github.com/amazeeio/litellm-lagoon-base. Tags track upstream
+    # stable releases. The package is internal, so the pulling cluster needs
+    # a ghcr.io dockerconfigjson secret referenced via imagePullSecrets.
+    repository: ghcr.io/amazeeio/litellm-lagoon-base-database
+    tag: "v1.93.0"
+  # imagePullSecrets:
+  #   - name: ghcr-pull-secret
   .aws_api_key: &aws-api-key
     aws_access_key_id: os.environ/AWS_ACCESS_KEY_ID
     aws_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
## What does this PR do?

Points the `litellm` chart at `ghcr.io/amazeeio/litellm-lagoon-base-database:v1.93.0` instead of upstream's `litellm-database:main-stable`, and bumps the chart to `0.8.0`.

That image is upstream LiteLLM plus our pending upstream patches — currently [BerriAI/litellm#31618](https://github.com/BerriAI/litellm/pull/31618) (budget threshold webhook alerts) — republished automatically for every upstream **stable** release by [amazeeio/litellm-lagoon-base](https://github.com/amazeeio/litellm-lagoon-base). The images also have LiteLLM's proprietary `enterprise/` code removed — everything else in LiteLLM is MIT, but the enterprise license forbids redistribution, and its features are dormant without a `LITELLM_LICENSE` key anyway. Once the upstream PR merges, the patch is removed there and the image becomes a 1-to-1 copy of upstream (minus those enterprise components); this chart keeps working unchanged.

Notes:

- **Pull secret required**: the `litellm-lagoon-base-database` package is **internal**, so clusters deploying this chart need a `kubernetes.io/dockerconfigjson` secret for `ghcr.io` (PAT with `read:packages`) and `litellm-helm.imagePullSecrets` set to it — a commented example is in `values.yaml`. Without it, pods will `ImagePullBackOff`. If we'd rather avoid per-cluster secrets, the package can be flipped to public instead.
- **Pinned tag instead of `main-stable`**: tags now track upstream stable releases (`v1.93.0` is the latest as of this PR). Bumping LiteLLM becomes an explicit tag change here rather than mutable-tag drift; a `latest` tag also exists if the previous behaviour is preferred.
- The `litellm-helm` chart dependency stays at `1.83.14-stable.patch.3` — only the image changes.

## Related issue(s)

- Relates to [BerriAI/litellm#31618](https://github.com/BerriAI/litellm/pull/31618) (the carried patch)

## Related changes

- [amazeeio/litellm-lagoon-base](https://github.com/amazeeio/litellm-lagoon-base) — builds and publishes the patched images this chart consumes
- amazeeio/litellm-lagoon — its proxy image moves to the plain `litellm-lagoon-base` variant of the same package

## Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change which adds no functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How has this been tested?

- The patched image was built and smoke-tested: all new pydantic fields (`budget_alert_thresholds` on key/team/user requests, `budget_percentage_used` on `CallInfo`, the `SlackAlertingArgs` threshold settings) and the new `auth_checks` alert functions are present and importable.
- This branch's push published `0.8.0-litellm-lagoon-base-image` to GHCR via the existing chart workflow, so it can be test-deployed before merging.
- Not yet deployed to a k0rdent cluster (blocked on the ghcr pull secret, see notes above).

## How and when this is going to be rolled out?

Merge publishes chart `0.8.0` to GHCR. Clusters pick it up when their template/chart version is bumped; the ghcr pull secret must be in place in the target namespaces first.

## Checklist

- [ ] Assign yourself as the Assignee of this MR.
- [x] Review your changes before adding any reviewers.
- [x] (If applicable) Documentation is updated (README, Notion etc.)
- [x] If you have multiple commits, please combine them into a few logically organized commits by squashing them.
- [x] This PR contains substantial use of AI-assisted coding tools.

## Status

- [x] Ready for Review
