### PR TITLE
litellm 0.7.3: v2 migration resolver + drop upstream demo models

### DIFF
--- a/charts/litellm/Chart.yaml
+++ b/charts/litellm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: litellm
 description: A Helm chart to refer the official litellm helm chart
 type: application
-version: 0.7.2
+version: 0.7.3
 dependencies:
   - name: litellm-helm
     version: 1.83.14-stable.patch.3

--- a/charts/litellm/templates/migrations-job.yaml
+++ b/charts/litellm/templates/migrations-job.yaml
@@ -1,0 +1,62 @@
+{{- $llm := index .Values "litellm-helm" }}
+{{- if and $llm.enabled (not ($llm.migrationJob).enabled) }}
+# Replacement for the upstream litellm-helm migrations job. Upstream's
+# entrypoint (python litellm/proxy/prisma_migration.py) is hard-wired to the
+# v1 migration resolver, whose diff-and-force recovery can drop and recreate
+# tables during rolling deploys — this wiped LiteLLM_ProxyModelTable on
+# amazeeai-us1. `litellm --skip_server_startup` runs the exact same database
+# setup, and --use_v2_migration_resolver opts into the safe resolver (LiteLLM's
+# own recommendation for this failure mode). Renders only while the upstream
+# job is disabled (litellm-helm.migrationJob.enabled=false), so re-enabling
+# upstream never yields two competing jobs.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-litellm-migrations-v2
+  annotations:
+    helm.sh/hook: "pre-install,pre-upgrade"
+    helm.sh/hook-delete-policy: "before-hook-creation"
+    helm.sh/hook-weight: "1"
+    checksum/config: {{ toYaml $llm | sha256sum }}
+spec:
+  backoffLimit: 4
+  # Keep finished pods for a day: upstream's 120s TTL deleted the pod (and its
+  # logs) before anyone could diagnose a destructive migration run.
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: prisma-migrations
+          image: "{{ ($llm.image).repository | default "ghcr.io/berriai/litellm-database" }}:{{ ($llm.image).tag | default "main-stable" }}"
+          command: ["litellm", "--skip_server_startup", "--use_v2_migration_resolver"]
+          workingDir: "/app"
+          env:
+            # ponytail: only the db.useExisting layout our clusters use; add the
+            # deployStandalone branch from upstream's template if ever needed.
+            - name: DATABASE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $llm.db.secret.name }}
+                  key: {{ $llm.db.secret.usernameKey }}
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $llm.db.secret.name }}
+                  key: {{ $llm.db.secret.passwordKey }}
+            - name: DATABASE_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $llm.db.secret.name }}
+                  key: {{ $llm.db.secret.endpointKey }}
+            - name: DATABASE_NAME
+              value: {{ $llm.db.database }}
+            - name: DATABASE_URL
+              value: {{ $llm.db.url | quote }}
+            {{- range $key, $val := $llm.envVars }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+            - name: DISABLE_SCHEMA_UPDATE
+              value: "false" # this job IS the schema update; proxy pods keep it disabled
+{{- end }}

--- a/charts/litellm/values.yaml
+++ b/charts/litellm/values.yaml
@@ -44,7 +44,21 @@ litellm-helm:
   #     UI_USERNAME: admin
   #     UI_PASSWORD: fillme
 
+  # The upstream migrations job is replaced by templates/migrations-job.yaml:
+  # its entrypoint (litellm/proxy/prisma_migration.py) is pinned to the v1
+  # migration resolver, whose diff-and-force recovery can drop and recreate
+  # tables during rolling deploys (this wiped LiteLLM_ProxyModelTable on
+  # amazeeai-us1). Our job runs the same setup with the v2 resolver. Setting
+  # this back to true restores the upstream job and disables ours.
+  migrationJob:
+    enabled: false
+
   proxy_config:
+    # Upstream ships two demo models (gpt-3.5-turbo, fake-openai-endpoint)
+    # as its default model_list, which leaks into every cluster that does not
+    # define its own. Models come from the amazee.ai model catalog (or an
+    # explicit model_list in the cluster file), never from chart defaults.
+    model_list: []
 
     litellm_settings:
       drop_params: true


### PR DESCRIPTION
## Why

During the 2026-08-10 us1 rollout, LiteLLM's migration job (which the chart runs as a helm hook on every upgrade) wiped `LiteLLM_ProxyModelTable` — all DB-managed models vanished while keys and access groups survived. The upstream job's entrypoint (`python litellm/proxy/prisma_migration.py`) is hard-wired to the **v1 migration resolver**, and LiteLLM's own CLI warns about exactly this:

> *Using default (v1) migration resolver. If your deployment has seen schema thrashing during rolling deploys, try --use_v2_migration_resolver (safer: avoids the diff-and-force recovery that caused the thrash).*

The flag has no env-var hookup in v1.95.0 and the job command isn't overridable via chart values, so the job must be replaced to pass it.

## Changes (chart 0.7.2 → 0.7.3)

1. **`templates/migrations-job.yaml`** — replacement migrations job running `litellm --skip_server_startup --use_v2_migration_resolver` (identical DB setup path, same helm pre-install/pre-upgrade hooks, same env wiring). `ttlSecondsAfterFinished: 86400` so job logs survive long enough to diagnose a bad rollout (upstream's 120s TTL is why the us1 logs were already gone). Renders only while `litellm-helm.migrationJob.enabled=false`, so re-enabling upstream never yields two jobs.
2. **`migrationJob.enabled: false`** — disables the upstream v1 job.
3. **`proxy_config.model_list: []`** — upstream's default model_list ships two demo models (`gpt-3.5-turbo`, `fake-openai-endpoint`) that leak into any cluster without its own model_list (currently visible on us1 and de1). Catalog-managed clusters get models from api.amazee.ai; clusters that still define `model_list` in their cluster file override this and are unaffected.

## Validation

`helm template` (with dependency build): renders exactly one migrations job (the v2 one), `model_list: []` in the proxy config, zero demo-model references. Full rendered output diff available on request.

## Rollout

Companion PR in amazeeai-k0rdent-clusters adds ServiceTemplate `litellm-0.5.5` → chart 0.7.3 and bumps **us1 and de1 only** (staged; prod clusters keep 0.5.4 until this proves out). Note for the test rollout: if a migration-job run does anything destructive again, the amazee.ai reconcile cron restores the models within 5 minutes — and this time the job logs will still be there to read.