### PR TITLE
Add LiteLLM production defaults to the litellm chart

### DIFF
--- a/charts/litellm/Chart.yaml
+++ b/charts/litellm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: litellm
 description: A Helm chart to refer the official litellm helm chart
 type: application
-version: 0.7.2
+version: 0.7.3
 dependencies:
   - name: litellm-helm
     version: 1.83.14-stable.patch.3

--- a/charts/litellm/values.yaml
+++ b/charts/litellm/values.yaml
@@ -44,15 +44,22 @@ litellm-helm:
   #     UI_USERNAME: admin
   #     UI_PASSWORD: fillme
 
+  envVars:
+    LITELLM_MODE: "PRODUCTION" # disables load_dotenv; all instances are consumers of LiteLLM
+    LITELLM_LOG: "ERROR" # error-level logging only
+
   proxy_config:
 
     litellm_settings:
       drop_params: true
+      request_timeout: 600 # fail requests after 10 min instead of litellm's 100 min default (ingress cuts at 660s anyway)
 
     general_settings:
       master_key: os.environ/PROXY_MASTER_KEY
       store_model_in_db: true
       store_prompts_in_spend_logs: false # This should only be true for specific debugging.
+      proxy_batch_write_at: 60 # batch spend/db writes every 60s instead of per-request
+      database_connection_pool_limit: 10 # cap prisma pool per pod
 
   livenessProbe:
     timeoutSeconds: 3


### PR DESCRIPTION
## What does this PR do?

Ports the LiteLLM production settings from [amazeeai-k0rdent-clusters#154](https://github.com/amazeeio/amazeeai-k0rdent-clusters/pull/154) into the base `litellm` chart, per review feedback there — these settings should apply to **all** instances rather than being repeated per cluster.

| Setting | Where | Effect |
|---|---|---|
| `LITELLM_MODE: "PRODUCTION"` | `envVars` | Skips `load_dotenv()`. All instances are consumers of LiteLLM and should run in production mode. |
| `LITELLM_LOG: "ERROR"` | `envVars` | Error-level logging only. |
| `request_timeout: 600` | `litellm_settings` | 10-minute request cap instead of LiteLLM's 100-minute default; ingress already cuts at 660s. |
| `proxy_batch_write_at: 60` | `general_settings` | Batches spend/DB writes every 60s instead of per-request. |
| `database_connection_pool_limit: 10` | `general_settings` | Caps the Prisma pool per pod. |

Not ported:

- `store_model_in_db: true` — already set in this chart.
- `json_logs: true` — dropped per review feedback (no log aggregation, so it does nothing).

Cluster-level `envVars` and `proxy_config` values deep-merge on top of these defaults, so existing per-cluster settings (AWS regions, model lists, etc.) are unaffected.

Chart version bumped `0.7.2` → `0.7.3`.

## Related issue(s)

<!-- none -->

## Related changes

- Replaces the per-cluster settings in [amazeeai-k0rdent-clusters#153](https://github.com/amazeeio/amazeeai-k0rdent-clusters/pull/153) and [amazeeai-k0rdent-clusters#154](https://github.com/amazeeio/amazeeai-k0rdent-clusters/pull/154). Once this chart version is consumed by the clusters, those PRs can be slimmed down or closed.

## Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change which adds no functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How has this been tested?

- YAML syntax validated. Not yet rendered against a real cluster values file — hence Draft.
- The same settings are already validated per-cluster in clusters#153/#154.

## How and when this is going to be rolled out?

Draft until we agree this is the right home for these settings. Rollout happens when clusters bump to chart `0.7.3` — dev/staging first, then prod, matching the plan in clusters#153/#154. Two things to watch on prod: spend data becomes up to 60s stale (budget enforcement goes eventually consistent), and `request_timeout: 600` is a new hard cap for long-running requests.

## Checklist

- [x] Assign yourself as the Assignee of this MR.
- [x] Review your changes before adding any reviewers.
- [ ] (If applicable) Documentation is updated (README, Notion etc.)
- [x] If you have multiple commits, please combine them into a few logically organized commits by squashing them.
- [x] This PR contains substantial use of AI-assisted coding tools.

## Status

- [ ] Ready for Review
